### PR TITLE
Do not download the "latest" jar on every test run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+
+# IntelliJ
+.idea

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ To use a specific version ("latest" is the default DynamoDB version to download 
 dynamoDBLocalVersion := "2014-10-07"
 ```
 
+If the "latest" version is being used, specify how old the downloaded copy should be before attempting a new download (default is 2 days)
+
+```
+import scala.concurrent.duration._
+dynamoDBLocalDownloadIfOlderThan := 2.days
+```
+
 To specify a port other than the default `8000`
 
 ```

--- a/src/main/scala/com/teambytes/sbt/dynamodb/DynamoDBLocal.scala
+++ b/src/main/scala/com/teambytes/sbt/dynamodb/DynamoDBLocal.scala
@@ -5,6 +5,7 @@ import sbt.Keys._
 
 import java.net.URL
 import java.io.File
+import scala.concurrent.duration._
 
 object DynamoDBLocal extends AutoPlugin {
 
@@ -16,11 +17,13 @@ object DynamoDBLocal extends AutoPlugin {
   private val DynamoDBLocalLibDir = "DynamoDBLocal_lib"
   private val DynamoDBLocalJar = "DynamoDBLocal.jar"
   private val DefaultPort = 8000
+  private val DefaultDynamoDBLocalDownloadIfOlderThan = 2 days
 
   object Keys {
     val dynamoDBLocalVersion = settingKey[String]("DynamoDB Local version to download.")
     val dynamoDBLocalDownloadUrl = settingKey[Option[String]]("DynamoDB Local URL to download jar from (optional).")
     val dynamoDBLocalDownloadDirectory = settingKey[File]("The directory DynamoDB Local jar will be downloaded to.")
+    val dynamoDBLocalDownloadIfOlderThan = settingKey[Duration]("Re-download the jar if the existing one is older than this.")
     val dynamoDBLocalPort = settingKey[Option[Int]]("The port number that DynamoDB Local will use to communicate with your application. If you do not specify this option, the default port is 8000.")
     val dynamoDBLocalDBPath = settingKey[Option[String]]("The directory where DynamoDB Local will write its database file. If you do not specify this option, the file will be written to the current directory.")
     val dynamoDBLocalInMemory = settingKey[Boolean]("Instead of using a database file, DynamoDB Local will run in memory. When you stop DynamoDB Local, none of the data will be saved.")
@@ -37,20 +40,21 @@ object DynamoDBLocal extends AutoPlugin {
   def settings: Seq[Setting[_]] = Seq(
     dynamoDBLocalVersion := DefaultDynamoDBLocalVersion,
     dynamoDBLocalDownloadUrl := None,
+    dynamoDBLocalDownloadIfOlderThan := DefaultDynamoDBLocalDownloadIfOlderThan,
     dynamoDBLocalPort := Some(DefaultPort),
     dynamoDBLocalDBPath := None,
     dynamoDBLocalInMemory := true,
     stopDynamoDBLocalAfterTests := true,
     cleanDynamoDBLocalAfterStop := true,
-    deployDynamoDBLocal <<= (dynamoDBLocalVersion, dynamoDBLocalDownloadUrl, dynamoDBLocalDownloadDirectory, streams) map {
-      case (ver, url, targetDir, streamz) =>
+    deployDynamoDBLocal <<= (dynamoDBLocalVersion, dynamoDBLocalDownloadUrl, dynamoDBLocalDownloadDirectory, dynamoDBLocalDownloadIfOlderThan, streams) map {
+      case (ver, url, targetDir, downloadIfOlderThan, streamz) =>
         import sys.process._
         val outputFile = new File(targetDir, s"dynamodb_local_$ver.tar.gz")
         if(!targetDir.exists()){
           streamz.log.info(s"Creating DynamoDB Local directory $targetDir:")
           targetDir.mkdirs()
         }
-        if(!outputFile.exists() || ver == "latest") {
+        if(!outputFile.exists() || ((ver == "latest") && (System.currentTimeMillis - outputFile.lastModified() > downloadIfOlderThan.toMillis))) {
           val remoteFile= url.getOrElse(DefaultDynamoDBLocalUrlTemplate(ver))
           streamz.log.info(s"Downloading DynamoDB Local from [$remoteFile] to [${outputFile.getAbsolutePath}]")
           (new URL(remoteFile) #> outputFile).!!


### PR DESCRIPTION
If `dynamoDBLocalVersion` is set to `latest`, the current behaviour of the plugin is to download the DynamoDB jar on every invocation of the test task. This slows down tests quite a bit. Since updates to DynamoDB Local are not very frequent, this PR adds a check to download the jar only if the current copy is older than a specified amount of time. Users are able to specify the wait duration using the `dynamoDBLocalDownloadIfOlderThan` setting.
