### PR TITLE
Support test configuration where DynamoDB was never started

### DIFF
--- a/src/main/scala/com/teambytes/sbt/dynamodb/DynamoDBLocal.scala
+++ b/src/main/scala/com/teambytes/sbt/dynamodb/DynamoDBLocal.scala
@@ -95,8 +95,8 @@ object DynamoDBLocal extends AutoPlugin {
           dynamoDBLocalPid := pid
           pid
         }.getOrElse {
-          streamz.log.error(s"Cannot find dynamodb local PID")
-          sys.exit(1)
+          // This is ok - it just means that DynamoDB isn't running, most likely because it was never started. :-)
+          "0"
         }
     },
     stopDynamoDBLocal <<= (dynamoDBLocalPid, dynamoDBLocalDBPath, cleanDynamoDBLocalAfterStop) map {
@@ -106,7 +106,7 @@ object DynamoDBLocal extends AutoPlugin {
     //make sure to Stop DynamoDB Local when tests are done.
     testOptions in Test <+= (dynamoDBLocalPid, stopDynamoDBLocalAfterTests, cleanDynamoDBLocalAfterStop, dynamoDBLocalDBPath) map {
       case (pid, stop, cln, dbPath) => Tests.Cleanup(() => {
-        if(stop) killDynamoDBLocal(cln, dbPath, pid)
+        if(stop && pid != "0") killDynamoDBLocal(cln, dbPath, pid)
       })
     }
   )

--- a/src/main/scala/com/teambytes/sbt/dynamodb/DynamoDBLocal.scala
+++ b/src/main/scala/com/teambytes/sbt/dynamodb/DynamoDBLocal.scala
@@ -96,6 +96,7 @@ object DynamoDBLocal extends AutoPlugin {
           pid
         }.getOrElse {
           // This is ok - it just means that DynamoDB isn't running, most likely because it was never started. :-)
+          streamz.log.info(s"Cannot find dynamodb local PID")
           "0"
         }
     },


### PR DESCRIPTION
This deals with issue #3. If you have a test configuration that doesn't start DynamoDB, the plugin will exit hard (sys.exit(1)) when setting up test  cleanup. Changed this so that the plugin handles non-running DynamoDB gracefully.
